### PR TITLE
fix typo

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -12,7 +12,8 @@ module.exports = function (opts) {
     headers.push.apply(headers, opts.headers)
   }
   if (Array.isArray(opts.methods)) {
-    methods.push.appy(methods, opts.methods)
+    methods.length = 0;
+    methods.push.apply(methods, opts.methods)
   }
 
   return function cors (req, res, next) {


### PR DESCRIPTION
also specify the exact verbs for CORS instead of adding new ones to the default list