### PR TITLE
[BUG]: Content-length header can be invalid

### DIFF
--- a/lib/make-res.js
+++ b/lib/make-res.js
@@ -12,9 +12,8 @@ module.exports = function makeRes (res) {
     if (typeof content !== 'string') {
       content = stringify(content)
     }
-    if (!res.headersSent) {
-      res.writeHead(code, {'content-length': content.length})
-    }
+
+    res.statusCode = code
     res.end(content, 'utf8')
   }
 


### PR DESCRIPTION
Thanks to javascript and unicode and counting characters, you can get a content-
length header that is actually shorter than your content. Compliant HTTP agents
will truncate at that point, possibly causing data corruption or invalid
JSON objects.