### PR TITLE
fix: don't parse multipart at all

### DIFF
--- a/lib/parse-body.js
+++ b/lib/parse-body.js
@@ -4,7 +4,7 @@ module.exports = function (maxSize) {
   return function parseBody (req, res, next) {
     const conlen = parseInt(req.headers['content-length'], 10) || 0
     const type = req.headers['content-type']
-    if (conlen === 0) {
+    if (conlen === 0 || type !== 'application/json') {
       return next()
     }
 
@@ -20,14 +20,10 @@ module.exports = function (maxSize) {
 
       req.on('end', () => {
         const data = body.join('')
-        if (data && type === 'application/json') {
-          try {
-            req.body = JSON.parse(data)
-          } catch (err) {
-            return res.err(400, 'Payload is not valid JSON')
-          }
-        } else {
-          req.body = data
+        try {
+          req.body = JSON.parse(data)
+        } catch (err) {
+          return res.err(400, 'Payload is not valid JSON')
         }
         next()
       })

--- a/test/take-five.spec.js
+++ b/test/take-five.spec.js
@@ -178,7 +178,7 @@ test('take five', (t) => {
     const headers = {'content-type': 'multipart/form-data'}
     sendRequest('post', '/', 'data goes here', headers, (err, res, body) => {
       t.error(err, 'no error')
-      t.equal(res.statusCode, 201, 'is fine')
+      t.equal(res.statusCode, 200, 'is fine')
       t.end()
     })
   })


### PR DESCRIPTION
## changes

- skip `parseBody` if content is not `application/json`
  - if it's multipart, request needs to be unmodified so parsers can read the stream (stream can only be read once)

## version

patch